### PR TITLE
Improvements

### DIFF
--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
@@ -21,6 +21,7 @@ ModelCheckerEnvironment::ModelCheckerEnvironment() {
     steadyStateDistributionAlgorithm = ioSettings.getSteadyStateDistributionAlgorithm();
 
     conditionalAlgorithmSetting = mcSettings.getConditionalAlgorithmSetting();
+    allowOptimizationForBoundedProperties = true;
 }
 
 ModelCheckerEnvironment::~ModelCheckerEnvironment() {
@@ -41,6 +42,14 @@ ConditionalAlgorithmSetting ModelCheckerEnvironment::getConditionalAlgorithmSett
 
 void ModelCheckerEnvironment::setConditionalAlgorithmSetting(ConditionalAlgorithmSetting value) {
     conditionalAlgorithmSetting = value;
+}
+
+bool ModelCheckerEnvironment::isAllowOptimizationForBoundedPropertiesSet() const {
+    return allowOptimizationForBoundedProperties;
+}
+
+void ModelCheckerEnvironment::setAllowOptimizationForBoundedProperties(bool value) {
+    allowOptimizationForBoundedProperties = value;
 }
 
 MultiObjectiveModelCheckerEnvironment& ModelCheckerEnvironment::multi() {

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
@@ -28,6 +28,9 @@ class ModelCheckerEnvironment {
     ConditionalAlgorithmSetting getConditionalAlgorithmSetting() const;
     void setConditionalAlgorithmSetting(ConditionalAlgorithmSetting value);
 
+    bool isAllowOptimizationForBoundedPropertiesSet() const;
+    void setAllowOptimizationForBoundedProperties(bool value);
+
     bool isLtl2daToolSet() const;
     std::string const& getLtl2daTool() const;
     void setLtl2daTool(std::string const& value);
@@ -38,5 +41,6 @@ class ModelCheckerEnvironment {
     boost::optional<std::string> ltl2daTool;
     SteadyStateDistributionAlgorithm steadyStateDistributionAlgorithm;
     ConditionalAlgorithmSetting conditionalAlgorithmSetting;
+    bool allowOptimizationForBoundedProperties;
 };
 }  // namespace storm

--- a/src/storm/modelchecker/helper/conditional/ConditionalAlgorithmSetting.cpp
+++ b/src/storm/modelchecker/helper/conditional/ConditionalAlgorithmSetting.cpp
@@ -11,6 +11,10 @@ std::ostream& operator<<(std::ostream& stream, ConditionalAlgorithmSetting const
             return stream << "bisection";
         case ConditionalAlgorithmSetting::BisectionAdvanced:
             return stream << "bisection-advanced";
+        case ConditionalAlgorithmSetting::BisectionPolicyTracking:
+            return stream << "bisection-pt";
+        case ConditionalAlgorithmSetting::BisectionAdvancedPolicyTracking:
+            return stream << "bisection-advanced-pt";
         case ConditionalAlgorithmSetting::PolicyIteration:
             return stream << "pi";
     }
@@ -27,6 +31,10 @@ ConditionalAlgorithmSetting conditionalAlgorithmSettingFromString(std::string co
         return ConditionalAlgorithmSetting::Bisection;
     } else if (algorithm == "bisection-advanced") {
         return ConditionalAlgorithmSetting::BisectionAdvanced;
+    } else if (algorithm == "bisection-pt") {
+        return ConditionalAlgorithmSetting::BisectionPolicyTracking;
+    } else if (algorithm == "bisection-advanced-pt") {
+        return ConditionalAlgorithmSetting::BisectionAdvancedPolicyTracking;
     } else if (algorithm == "pi") {
         return ConditionalAlgorithmSetting::PolicyIteration;
     }

--- a/src/storm/modelchecker/helper/conditional/ConditionalAlgorithmSetting.h
+++ b/src/storm/modelchecker/helper/conditional/ConditionalAlgorithmSetting.h
@@ -5,7 +5,15 @@
 #include "storm/utility/macros.h"
 
 namespace storm {
-enum class ConditionalAlgorithmSetting { Default, Restart, Bisection, BisectionAdvanced, PolicyIteration };
+enum class ConditionalAlgorithmSetting {
+    Default,
+    Restart,
+    Bisection,
+    BisectionAdvanced,
+    BisectionPolicyTracking,
+    BisectionAdvancedPolicyTracking,
+    PolicyIteration
+};
 
 std::ostream& operator<<(std::ostream& stream, ConditionalAlgorithmSetting const& algorithm);
 ConditionalAlgorithmSetting conditionalAlgorithmSettingFromString(std::string const& algorithm);

--- a/src/storm/settings/modules/ModelCheckerSettings.cpp
+++ b/src/storm/settings/modules/ModelCheckerSettings.cpp
@@ -26,7 +26,7 @@ ModelCheckerSettings::ModelCheckerSettings() : ModuleSettings(moduleName) {
                                          .build())
                         .build());
 
-    std::vector<std::string> const conditionalAlgs = {"default", "restart", "bisection", "bisection-advanced", "pi"};
+    std::vector<std::string> const conditionalAlgs = {"default", "restart", "bisection", "bisection-advanced", "bisection-pt", "bisection-advanced-pt", "pi"};
     this->addOption(storm::settings::OptionBuilder(moduleName, conditionalAlgorithmOptionName, false, "The used algorithm for conditional probabilities.")
                         .setIsAdvanced()
                         .addArgument(storm::settings::ArgumentBuilder::createStringArgument("name", "The name of the method to use.")

--- a/src/storm/solver/SolveGoal.cpp
+++ b/src/storm/solver/SolveGoal.cpp
@@ -110,6 +110,11 @@ bool SolveGoal<ValueType, SolutionType>::isRobust() const {
 }
 
 template<typename ValueType, typename SolutionType>
+storm::logic::ComparisonType SolveGoal<ValueType, SolutionType>::boundComparisonType() const {
+    return comparisonType.get();
+}
+
+template<typename ValueType, typename SolutionType>
 SolutionType const& SolveGoal<ValueType, SolutionType>::thresholdValue() const {
     return threshold.get();
 }

--- a/src/storm/solver/SolveGoal.h
+++ b/src/storm/solver/SolveGoal.h
@@ -84,6 +84,8 @@ class SolveGoal {
 
     bool boundIsStrict() const;
 
+    storm::logic::ComparisonType boundComparisonType() const;
+
     SolutionType const& thresholdValue() const;
 
     bool hasRelevantValues() const;

--- a/src/storm/storage/MaximalEndComponentDecomposition.cpp
+++ b/src/storm/storage/MaximalEndComponentDecomposition.cpp
@@ -150,6 +150,8 @@ void MaximalEndComponentDecomposition<ValueType>::performMaximalEndComponentDeco
                                                                                           storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                                           storm::OptionalRef<storm::storage::BitVector const> states,
                                                                                           storm::OptionalRef<storm::storage::BitVector const> choices) {
+    STORM_LOG_ASSERT(!states.has_value() || transitionMatrix.getRowGroupCount() == states->size(), "Unexpected size of states bitvector.");
+    STORM_LOG_ASSERT(!choices.has_value() || transitionMatrix.getRowCount() == choices->size(), "Unexpected size of choices bitvector.");
     // Get some data for convenient access.
     auto const& nondeterministicChoiceIndices = transitionMatrix.getRowGroupIndices();
 

--- a/src/test/storm/modelchecker/prctl/mdp/ConditionalMdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/ConditionalMdpPrctlModelCheckerTest.cpp
@@ -49,6 +49,30 @@ class SparseDoubleBisectionAdvancedEnvironment {
     }
 };
 
+class SparseDoubleBisectionPtEnvironment {
+   public:
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Mdp<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setConditionalAlgorithmSetting(storm::ConditionalAlgorithmSetting::BisectionPolicyTracking);
+        return env;
+    }
+};
+
+class SparseDoubleBisectionAdvancedPtEnvironment {
+   public:
+    static const bool isExact = false;
+    typedef double ValueType;
+    typedef storm::models::sparse::Mdp<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setConditionalAlgorithmSetting(storm::ConditionalAlgorithmSetting::BisectionAdvancedPolicyTracking);
+        return env;
+    }
+};
+
 class SparseDoublePiEnvironment {
    public:
     static const bool isExact = false;
@@ -94,6 +118,30 @@ class SparseRationalNumberBisectionAdvancedEnvironment {
     static storm::Environment createEnvironment() {
         storm::Environment env;
         env.modelchecker().setConditionalAlgorithmSetting(storm::ConditionalAlgorithmSetting::BisectionAdvanced);
+        return env;
+    }
+};
+
+class SparseRationalNumberBisectionPtEnvironment {
+   public:
+    static const bool isExact = true;
+    typedef storm::RationalNumber ValueType;
+    typedef storm::models::sparse::Mdp<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setConditionalAlgorithmSetting(storm::ConditionalAlgorithmSetting::BisectionPolicyTracking);
+        return env;
+    }
+};
+
+class SparseRationalNumberBisectionAdvancedPtEnvironment {
+   public:
+    static const bool isExact = true;
+    typedef storm::RationalNumber ValueType;
+    typedef storm::models::sparse::Mdp<ValueType> ModelType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.modelchecker().setConditionalAlgorithmSetting(storm::ConditionalAlgorithmSetting::BisectionAdvancedPolicyTracking);
         return env;
     }
 };
@@ -159,9 +207,10 @@ class ConditionalMdpPrctlModelCheckerTest : public ::testing::Test {
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<SparseDoubleRestartEnvironment, SparseDoubleBisectionEnvironment, SparseDoubleBisectionAdvancedEnvironment, SparseDoublePiEnvironment,
+typedef ::testing::Types<SparseDoubleRestartEnvironment, SparseDoubleBisectionEnvironment, SparseDoubleBisectionAdvancedEnvironment,
+                         SparseDoubleBisectionPtEnvironment, SparseDoubleBisectionAdvancedPtEnvironment, SparseDoublePiEnvironment,
                          SparseRationalNumberRestartEnvironment, SparseRationalNumberBisectionEnvironment, SparseRationalNumberBisectionAdvancedEnvironment,
-                         SparseRationalNumberPiEnvironment>
+                         SparseRationalNumberBisectionPtEnvironment, SparseRationalNumberBisectionAdvancedPtEnvironment, SparseRationalNumberPiEnvironment>
     TestingTypes;
 
 TYPED_TEST_SUITE(ConditionalMdpPrctlModelCheckerTest, TestingTypes, );


### PR DESCRIPTION
Scheduler extraction

I made a pass over the implementation for extracting schedulers. We now pre-compute the various index mappings (e.g. from EC eliminated system to original model) instead of translating the indices ad-hoc. This should be faster and is arguably more readable / less error prone. Also, we now only do the extra work if a scheduler is actually requested.
My rewrites should be equivalent to what has been done before but these index translations are easy to get wrong and I don't really have means to test that.

Policy tracking variants

I added the "policy tracking" variants of the bisection method (use --conditional bisection-pt or --conditional bisection-advanced-pt). These check if the policies for the lower- and upper bound agree and then terminate the bisection early

Optimizations for bounded properties

I added optimizations for thresholded properties. In particular, the bisection variants now terminate in a single "bisection step" when loaded with a thresholded property. This should also produce schedulers that satisfy/violate the threshold, but the schedulers are not necessarily optimal. This functionality can be disabled by setting env.modelchecker().setAllowOptimizationForBoundedProperties(false)